### PR TITLE
allow ruby to query druid coordinator

### DIFF
--- a/resources/files/redborder-manager.te
+++ b/resources/files/redborder-manager.te
@@ -13,6 +13,7 @@ require {
     type memcache_port_t;
     type useradd_t;
     type var_lib_t;
+    type transproxy_port_t;
     class tcp_socket name_connect;
     class file { append create execute execute_no_trans ioctl open read setattr unlink write };
     class dir rmdir;
@@ -24,6 +25,8 @@ allow init_t http_cache_port_t:tcp_socket name_connect;
 
 allow init_t httpd_sys_content_t:file { append create execute execute_no_trans ioctl open read setattr unlink write };
 allow init_t httpd_tmp_t:dir rmdir;
+
+allow init_t transproxy_port_t:tcp_socket name_connect;
 
 allow init_t lib_t:file write;
 allow init_t postgresql_port_t:tcp_socket name_connect;


### PR DESCRIPTION
since the ruby gem DruidConfig was not allowed to check the status of the druid coordinator, no valid coordinators were found and the service failed